### PR TITLE
Removed use statement for String

### DIFF
--- a/src/AverageRoll.php
+++ b/src/AverageRoll.php
@@ -7,7 +7,6 @@
 namespace Drupal\dicefield;
 
 use Drupal\Component\Utility\SafeMarkup;
-use Drupal\Component\Utility\String;
 use Drupal\Core\TypedData\DataDefinitionInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\Core\TypedData\TypedData;


### PR DESCRIPTION
The keyword 'String' is reserved PHP7 which throws an error when accessing the module configuration. Removing the initial use statement fixes the issue.