### PR TITLE
drupal 10 compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 An example Drupal 8 module to provide a custom "dice" field as a way of specifying a dice value such as 1d6 or 2d8+3.
 
 See http://www.ixis.co.uk/blog/drupal-8-creating-field-types-multiple-values
+
+The 10.1.x-dev branch has been tested on Drupal version 10.1.x-dev

--- a/dicefield.info.yml
+++ b/dicefield.info.yml
@@ -2,8 +2,6 @@ name: Dice field
 type: module
 description: A way of specifying a dice value such as 1d6 or 2d8+3.
 package: Field types
-version: 1.0
-core: 8.x
-
+core_version_requirement: ^9.4 || ^10
 dependencies:
   - field

--- a/dicefield.info.yml
+++ b/dicefield.info.yml
@@ -2,6 +2,7 @@ name: Dice field
 type: module
 description: A way of specifying a dice value such as 1d6 or 2d8+3.
 package: Field types
+version: 2.x
 core_version_requirement: ^9.4 || ^10
 dependencies:
   - field

--- a/src/AverageRoll.php
+++ b/src/AverageRoll.php
@@ -7,7 +7,6 @@
 namespace Drupal\dicefield;
 
 use Drupal\Component\Utility\SafeMarkup;
-use Drupal\Component\Utility\String;
 use Drupal\Core\TypedData\DataDefinitionInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\Core\TypedData\TypedData;


### PR DESCRIPTION
Hi, Thank you for the code. I am using the dicefield and dice field type as example code. I am hoping to develop the drupal contributed audiorecorder field type to store multiple text values. I am using the audiorecorder field type with Drupal 10.1.x-dev so I needed to make your module compatible with that Drupal version.

I am not sure if you want to merge this into master, but thought I would give you the option.